### PR TITLE
feat: add ability to have user provided context in hackrf_sweep_state

### DIFF
--- a/include/hackrf_sweeper.h
+++ b/include/hackrf_sweeper.h
@@ -303,6 +303,11 @@ typedef int (*hackrf_sweep_mutex_unlock_fn)(void *mutex);
 struct hackrf_sweep_state
 {
 	/**
+	 * User provided context.
+	 */
+	void *user_ctx;
+
+	/**
 	 * Maximum number of sweeps (if non-zero) for a finite run
 	 */
 	uint32_t max_sweeps;


### PR DESCRIPTION
Adds a void* to hackrf_sweep_state to allow the user to provide additional context. 